### PR TITLE
CDN_JS-Bootstrap

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -36,7 +36,7 @@
       rel="stylesheet"
     />
     <link rel="preconnect" href="https://fonts.gstatic.com" />
-    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.2.0-beta1/js/bootstrap.min.js"></script>
   </head>
 
   <body class="mat-typography">
@@ -44,4 +44,3 @@
     <app-root></app-root>
   </body>
 </html>
-


### PR DESCRIPTION
Menu hamburger n'ouvrait pas sous : 
    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/js/bootstrap.min.js"></script>

Je l'ai changé pour : 
    <script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.2.0-beta1/js/bootstrap.min.js"></script>
    
    Maintenant fonctionnel 
![image](https://user-images.githubusercontent.com/74875186/170713663-d4986bb8-f4d8-471c-a8ef-dcd3cffcf927.png)
